### PR TITLE
Fix memory leask of context and webViewController

### DIFF
--- a/sonic-iOS/SonicSample/SonicSample/SonicJSContext.h
+++ b/sonic-iOS/SonicSample/SonicSample/SonicJSContext.h
@@ -35,8 +35,7 @@ JSExportAs(getPerformance,
 
 @interface SonicJSContext : NSObject<SonicJSExport>
 
-//fix:https://github.com/Tencent/VasSonic/issues/251, make sure jscontext execute correct
-@property (nonatomic,strong)SonicWebViewController *owner;
+@property (nonatomic,weak)SonicWebViewController *owner;
 
 - (void)getDiffData:(NSDictionary *)option withCallBack:(JSValue *)jscallback;
 

--- a/sonic-iOS/SonicSample/SonicSample/SonicJSContext.m
+++ b/sonic-iOS/SonicSample/SonicSample/SonicJSContext.m
@@ -24,20 +24,19 @@
 
 - (void)getDiffData:(NSDictionary *)option withCallBack:(JSValue *)jscallback
 {
-    JSValue *callback = self.owner.jscontext.globalObject;
+    SonicWebViewController *owner = self.owner;
+    if (!owner) { return; }
     
-    __weak typeof(self) weakSelf = self;
-    [[SonicEngine sharedEngine] sonicUpdateDiffDataByWebDelegate:self.owner completion:^(NSDictionary *result) {
-       
-        if (result) {
-            
+    __weak typeof(SonicWebViewController *) weakOwner = owner;
+    [[SonicEngine sharedEngine] sonicUpdateDiffDataByWebDelegate:owner completion:^(NSDictionary *result) {
+        __strong typeof(SonicWebViewController *) strongOwner = weakOwner;
+        if (strongOwner && result) {
+            JSValue *callback = strongOwner.jscontext.globalObject;
             NSData *json = [NSJSONSerialization dataWithJSONObject:result options:NSJSONWritingPrettyPrinted error:nil];
             NSString *jsonStr = [[NSString alloc]initWithData:json encoding:NSUTF8StringEncoding];
             
             [callback invokeMethod:@"getDiffDataCallback" withArguments:@[jsonStr]];
         }
-        //fix:https://github.com/Tencent/VasSonic/issues/251
-        weakSelf.owner = nil;
     }];
 }
 

--- a/sonic-iOS/SonicSample/SonicSample/SonicWebViewController.m
+++ b/sonic-iOS/SonicSample/SonicSample/SonicWebViewController.m
@@ -60,9 +60,7 @@
 
 - (void)dealloc
 {
-    self.sonicContext.owner = nil;
     self.sonicContext = nil;
-    self.jscontext = nil;
     [[SonicEngine sharedEngine] removeSessionWithWebDelegate:self];
 }
 


### PR DESCRIPTION
Memory leaks when `JS` not called `getDiffData`.