### PR TITLE
Fix memory leaks in iOS

### DIFF
--- a/sonic-iOS/Sonic/Cache/SonicCache.m
+++ b/sonic-iOS/Sonic/Cache/SonicCache.m
@@ -514,6 +514,7 @@ typedef NS_ENUM(NSUInteger, SonicCacheType) {
         NSDateFormatter *dateFormatter = [NSDateFormatter new];
         [dateFormatter setDateFormat:@"EEE, dd MMM yyyy HH:mm:ss zzz"];
         NSDate *date = [dateFormatter dateFromString:expire];
+        [dateFormatter release];
         unsigned long long expireTime = (unsigned long long)[date timeIntervalSince1970];
         
         if (!date) {

--- a/sonic-iOS/Sonic/Network/SonicConnection.m
+++ b/sonic-iOS/Sonic/Network/SonicConnection.m
@@ -56,6 +56,7 @@
     
     self.dataTask = nil;
     self.dataSession = nil;
+    self.delegateQueue = nil;
     
     [super dealloc];
 }
@@ -87,6 +88,8 @@
     }else{
         [self.dataSession invalidateAndCancel];
     }
+    self.dataTask = nil;
+    self.dataSession = nil;
 }
 
 #pragma mark - NSURLSessionDelegate


### PR DESCRIPTION
I strongly recommend that transition `iOS` to `ARC`, just like discussion in #259 , I think `ARC` is more safety, robust and memory friendly.

This `PR` fixes:
1. Memory leaks of `NSDateFormatter`.
2. Memory leaks of `NSURLSession` and related classes.
3. Memory leaks of `SonicConnection`. 
4. Memory leaks of `delegateQueue` in `SonicConnection`. 
5. ...... any related memory leaks.