### PR TITLE
Remove operation cancelation when stop connection in iOS

### DIFF
--- a/sonic-iOS/Sonic/Network/SonicConnection.m
+++ b/sonic-iOS/Sonic/Network/SonicConnection.m
@@ -75,10 +75,6 @@
 - (void)stopLoading
 {
     self.delegate = nil;
-    //fix:https://github.com/Tencent/VasSonic/issues/253
-    for (NSOperation *operation in self.delegateQueue.operations) {
-        [operation cancel];
-    }
     self.delegateQueue = nil;
     
     if (self.dataTask && self.dataTask.state == NSURLSessionTaskStateRunning) {


### PR DESCRIPTION
The comment said fix #253 , I suspect the reason is memory leaks of connection, I make a `PR` #265 to fix it. 

This `PR`, I removed these cancellation, the reason is `delegateQueue` could be `sonicSessionQueue`, it's a global queue, all session related thing do on this queue. And if we don't do cancellation, it not have side-effect, because we already `nil` the `delegate`.