### PR TITLE
修改当OFFLINE_MODE_STORE为store时,sonic页面不缓存最新数据

### DIFF
--- a/sonic-android/sdk/src/main/java/com/tencent/sonic/sdk/QuickSonicSession.java
+++ b/sonic-android/sdk/src/main/java/com/tencent/sonic/sdk/QuickSonicSession.java
@@ -361,6 +361,7 @@ public class QuickSonicSession extends SonicSession implements Handler.Callback 
                 }
                 setResult(SONIC_RESULT_CODE_TEMPLATE_CHANGE, SONIC_RESULT_CODE_TEMPLATE_CHANGE, false);
             } else {
+                sessionClient.loadUrl(srcUrl, null);
                 SonicUtils.log(TAG, Log.INFO, "handleClientCoreMessage_TemplateChange:not refresh.");
                 setResult(SONIC_RESULT_CODE_TEMPLATE_CHANGE, SONIC_RESULT_CODE_HIT_CACHE, true);
             }


### PR DESCRIPTION
当当OFFLINE_MODE_STORE为store时,代码走到QuickSonicSession类的364行时,并没有去请求最新的页面数据,从而没有缓存最新的页面缓存.官方demo也可以验证此bug.
原因在于缺乏请求数据的一行代码.