### PR TITLE
iOS - 修复重新设置delegate没有设置delegateId 导致网页资源拦截失败的BUG

### DIFF
--- a/sonic-iOS/Sonic/Engine/SonicEngine.m
+++ b/sonic-iOS/Sonic/Engine/SonicEngine.m
@@ -225,6 +225,7 @@ static bool ValidateSessionDelegate(id<SonicSessionDelegate> aWebDelegate)
         
         if (existSession.delegate == nil) {
             existSession.delegate = aWebDelegate;
+            existSession.delegateId = [NSString stringWithFormat:@"%ld", (long)aWebDelegate.hash];
         }
     }
     


### PR DESCRIPTION
iOS - 修复重新设置delegate没有设置delegateId 导致网页资源拦截失败的BUG，希望能尽快更新到cocoapod上面